### PR TITLE
Implement App Mesh service discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ DOCKER_IMAGE_NAME:=$(DOCKER_REPOSITORY)/$(NAME)
 run:
 	go run cmd/kxds/*.go kubernetes --kubeconfig=$$HOME/.kube/config --ads=true --port-name=http
 
+appmesh:
+	go run cmd/kxds/*.go appmesh --kubeconfig=$$HOME/.kube/config --ads=true \
+		--gateway-mesh=appmesh --gateway-name=gateway --gateway-namespace=appmesh-gateway
+
 envoy:
 	envoy -c envoy.yaml -l info
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,25 @@ KxDS runs as a sidecar next to Envoy and configures the proxy to expose Kubernet
 
 ### Features
 
-* **Service Discovery** KxDS watches Kubernetes for ClusterIP services with a `http` named port
-* **Envoy Clusters (CDS)** are generated for each Kubernetes service in the form `<service-name>-<namespace>-<http-port>`
-* **Envoy Routes (RDS)** are generated for each cluster and mapped to the `<name>.<namespace>` domain
+* **Kubernetes Service Discovery** KxDS watches Kubernetes for services with a `http` named port
+* **App Mesh Service Discovery** KxDS watches Kubernetes for App Mesh virtual services
+* **Envoy Clusters (CDS)** are generated for each Kubernetes service or App Mesh virtual services
+* **Envoy Routes (RDS)** are generated for each cluster and configured with timeouts and retry policies
 * **Envoy Weighted Clusters** are generated based on Kubernetes service annotations
-* **Envoy Listeners (LDS)** KxDS configures Envoy to listen on port `8080` and sets up retry policies for each route
+* **Envoy Listeners (LDS)** KxDS configures Envoy to listen on port `8080`
 
 ### Install
 
+API Gateway for Kubernetes
+
 ```sh
 kubectl apply -k github.com/stefanprodan/kxds//kustomize/gateway
+```
+
+API Gateway for App Mesh
+
+```sh
+kubectl apply -k github.com/stefanprodan/kxds//kustomize/appmesh-gateway
 ```
 
 ### Annotations

--- a/cmd/kxds/appmesh.go
+++ b/cmd/kxds/appmesh.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/stefanprodan/kxds/pkg/discovery"
+	"k8s.io/client-go/dynamic"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
+
+	"github.com/stefanprodan/kxds/pkg/envoy"
+	"github.com/stefanprodan/kxds/pkg/server"
+	"github.com/stefanprodan/kxds/pkg/signals"
+)
+
+var gatewayMesh string
+var gatewayName string
+var gatewayNamespace string
+
+func init() {
+	appmeshCmd.Flags().StringVarP(&masterURL, "master", "", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	appmeshCmd.Flags().StringVarP(&kubeConfig, "kubeconfig", "", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+	appmeshCmd.Flags().IntVarP(&port, "port", "p", 18000, "Port to listen on.")
+	appmeshCmd.Flags().StringVarP(&namespace, "namespace", "", "", "Namespace to watch for App Mesh virtual service.")
+	appmeshCmd.Flags().BoolVarP(&ads, "ads", "", true, "ADS flag forces a delay in responding to streaming requests until all resources are explicitly named in the request.")
+	appmeshCmd.Flags().StringVarP(&gatewayMesh, "gateway-mesh", "", "", "App Mesh gateway mesh.")
+	appmeshCmd.Flags().StringVarP(&gatewayName, "gateway-name", "", "", "App Mesh gateway name.")
+	appmeshCmd.Flags().StringVarP(&gatewayNamespace, "gateway-namespace", "", "", "App Mesh gateway namespace.")
+
+	rootCmd.AddCommand(appmeshCmd)
+}
+
+var appmeshCmd = &cobra.Command{
+	Use:   `appmesh`,
+	Short: "Starts App Mesh discovery service",
+	RunE:  appmeshRun,
+}
+
+func appmeshRun(cmd *cobra.Command, args []string) error {
+	cfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeConfig)
+	if err != nil {
+		klog.Fatalf("error building kubeconfig: %v", err)
+	}
+
+	clientset, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		klog.Fatalf("error building kubernetes clientset: %v", err)
+	}
+
+	stopCh := signals.SetupSignalHandler()
+	ctx := context.Background()
+	cache := envoy.NewCache(ads)
+	snapshot := envoy.NewSnapshot(cache)
+
+	klog.Infof("starting xDS server on port %d", port)
+	srv := server.NewServer(port, cache)
+	go srv.Serve(ctx)
+
+	klog.Info("waiting for Envoy to connect to the xDS server")
+	srv.Report()
+
+	klog.Info("starting App Mesh discovery workers")
+	kd := discovery.NewAppmeshDiscovery(clientset, namespace, snapshot, gatewayMesh, gatewayName, gatewayNamespace)
+	kd.Run(2, stopCh)
+
+	return nil
+}

--- a/cmd/kxds/version.go
+++ b/cmd/kxds/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var VERSION = "0.0.4"
+var VERSION = "0.1.0"
 
 func init() {
 	rootCmd.AddCommand(versionCmd)

--- a/kustomize/appmesh-gateway/deployment.yaml
+++ b/kustomize/appmesh-gateway/deployment.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: appmesh-gateway
+  labels:
+    app: appmesh-gateway
+spec:
+  selector:
+    matchLabels:
+      app: appmesh-gateway
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: appmesh-gateway
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/stats/prometheus"
+        prometheus.io/port: "8081"
+        # exclude inbound traffic on port 8080
+        appmesh.k8s.aws/ports: "444"
+        # exclude egress traffic to KxDS and Kubernetes API
+        appmesh.k8s.aws/egressIgnoredPorts: "18000,22,443"
+    spec:
+      serviceAccountName: appmesh-gateway
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: gateway
+          image: "envoyproxy/envoy:v1.11.1"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - /docker-entrypoint.sh envoy --service-node ${POD_NAME} --service-cluster envoy --base-id 1234 -l info -c /config/envoy.yaml
+          ports:
+            - name: admin
+              containerPort: 8081
+              protocol: TCP
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            initialDelaySeconds: 5
+            tcpSocket:
+              port: admin
+          readinessProbe:
+            initialDelaySeconds: 5
+            tcpSocket:
+              port: admin
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+          volumeMounts:
+            - name: xds-config
+              mountPath: /config
+        - name: kxds
+          image: stefanprodan/kxds:0.1.0
+          imagePullPolicy: Always
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+          command:
+            - ./kxds
+            - appmesh
+            - --port=18000
+            - --ads=true
+            - --gateway-mesh=appmesh
+            - --gateway-name=$(POD_SERVICE_ACCOUNT)
+            - --gateway-namespace=$(POD_NAMESPACE)
+          env:
+            - name: POD_SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: grpc
+              containerPort: 18000
+              protocol: TCP
+          livenessProbe:
+            initialDelaySeconds: 5
+            tcpSocket:
+              port: grpc
+          readinessProbe:
+            initialDelaySeconds: 5
+            tcpSocket:
+              port: grpc
+      volumes:
+        - name: xds-config
+          configMap:
+            name: envoy

--- a/kustomize/appmesh-gateway/envoy.yaml
+++ b/kustomize/appmesh-gateway/envoy.yaml
@@ -1,0 +1,33 @@
+admin:
+  access_log_path: /dev/stdout
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8081
+
+dynamic_resources:
+  ads_config:
+    api_type: GRPC
+    grpc_services:
+      - envoy_grpc:
+          cluster_name: xds
+  cds_config:
+    ads: {}
+  lds_config:
+    ads: {}
+
+static_resources:
+  clusters:
+    - name: xds
+      connect_timeout: 0.30s
+      type: static
+      http2_protocol_options: {}
+      load_assignment:
+        cluster_name: xds
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 18000

--- a/kustomize/appmesh-gateway/kustomization.yaml
+++ b/kustomize/appmesh-gateway/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: appmesh-gateway
+resources:
+- namespace.yaml
+- deployment.yaml
+- rbac.yaml
+- service.yaml
+configMapGenerator:
+  - name: envoy
+    files:
+      - envoy.yaml

--- a/kustomize/appmesh-gateway/namespace.yaml
+++ b/kustomize/appmesh-gateway/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: appmesh-gateway
+  annotations:
+    fluxcd.io/ignore: "false"
+  labels:
+    appmesh.k8s.aws/sidecarInjectorWebhook: enabled

--- a/kustomize/appmesh-gateway/rbac.yaml
+++ b/kustomize/appmesh-gateway/rbac.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: appmesh-gateway
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: appmesh-gateway
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs: ["*"]
+  - apiGroups:
+      - appmesh.k8s.aws
+    resources:
+      - meshes
+      - meshes/status
+      - virtualnodes
+      - virtualnodes/status
+      - virtualservices
+      - virtualservices/status
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: appmesh-gateway
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appmesh-gateway
+subjects:
+- kind: ServiceAccount
+  name: appmesh-gateway
+  namespace: appmesh-gateway

--- a/kustomize/appmesh-gateway/service.yaml
+++ b/kustomize/appmesh-gateway/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: appmesh-gateway
+  labels:
+    app: appmesh-gateway
+  annotations:
+    envoy.gateway.kubernetes.io/expose: "false"
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+  selector:
+    app: appmesh-gateway

--- a/pkg/discovery/appmesh.go
+++ b/pkg/discovery/appmesh.go
@@ -1,0 +1,376 @@
+package discovery
+
+import (
+	"encoding/json"
+	"fmt"
+	"k8s.io/client-go/util/retry"
+	"strconv"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+
+	"github.com/stefanprodan/kxds/pkg/envoy"
+)
+
+// AppmeshDiscovery watches Kubernetes for App Mesh virtual services events and
+// pushes them to Envoy over xDS
+type AppmeshDiscovery struct {
+	clientset        dynamic.Interface
+	indexer          cache.Indexer
+	queue            workqueue.RateLimitingInterface
+	informer         cache.Controller
+	snapshot         *envoy.Snapshot
+	gatewayMesh      string
+	gatewayName      string
+	gatewayNamespace string
+}
+
+// NewAppmeshDiscovery starts watching for App Mesh virtual services
+func NewAppmeshDiscovery(clientset dynamic.Interface, namespace string, snapshot *envoy.Snapshot, gatewayMesh string, gatewayName string, gatewayNamespace string) *AppmeshDiscovery {
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(clientset, 0, namespace, nil)
+	gvr, _ := schema.ParseResourceArg("virtualservices.v1beta1.appmesh.k8s.aws")
+	vsFactory := factory.ForResource(*gvr)
+	informer := vsFactory.Informer()
+	indexer := vsFactory.Informer().GetIndexer()
+	handlers := cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			key, err := cache.MetaNamespaceKeyFunc(obj)
+			if err == nil {
+				queue.Add(key)
+			}
+		},
+		UpdateFunc: func(oldObj, obj interface{}) {
+			key, err := cache.MetaNamespaceKeyFunc(obj)
+			if err == nil {
+				queue.Add(key)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+			if err == nil {
+				queue.Add(key)
+			}
+		},
+	}
+	informer.AddEventHandler(handlers)
+
+	return &AppmeshDiscovery{
+		clientset:        clientset,
+		informer:         informer,
+		indexer:          indexer,
+		queue:            queue,
+		snapshot:         snapshot,
+		gatewayMesh:      gatewayMesh,
+		gatewayName:      gatewayName,
+		gatewayNamespace: gatewayNamespace,
+	}
+}
+
+// Run starts the App Mesh discovery controller
+func (kd *AppmeshDiscovery) Run(threadiness int, stopCh <-chan struct{}) {
+	defer runtime.HandleCrash()
+	defer kd.queue.ShutDown()
+
+	go kd.informer.Run(stopCh)
+
+	if !cache.WaitForCacheSync(stopCh, kd.informer.HasSynced) {
+		runtime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
+		return
+	}
+
+	kd.syncAll()
+
+	for i := 0; i < threadiness; i++ {
+		go wait.Until(kd.runWorker, time.Second, stopCh)
+	}
+
+	tickChan := time.NewTicker(5 * time.Minute).C
+	for {
+		select {
+		case <-tickChan:
+			kd.syncAll()
+		case <-stopCh:
+			klog.Info("stopping Kubernetes discovery workers")
+			return
+		}
+	}
+}
+
+func (kd *AppmeshDiscovery) sync(key string) error {
+	_, _, err := kd.indexer.GetByKey(key)
+	if err != nil {
+		klog.Errorf("fetching object with key %s from store failed %v", key, err)
+		return err
+	}
+	kd.syncAll()
+	return nil
+}
+
+func (kd *AppmeshDiscovery) syncAll() {
+	var backends []string
+	for _, value := range kd.indexer.List() {
+		un := value.(*unstructured.Unstructured)
+		vs, err := kd.toVirtualService(un)
+		if err != nil {
+			klog.Errorf("unmarshal object %s from store failed %v", un.GetName(), err)
+			return
+		}
+		if kd.svcIsValid(*vs) {
+			backends = append(backends, vs.Name)
+			kd.snapshot.Store(fmt.Sprintf("%s/%s", vs.Namespace, vs.Name), kd.svcToUpstream(*vs))
+		}
+	}
+
+	klog.Infof("updating gateway virtual node with %d backends", len(backends))
+	err := kd.updateVirtualNode(backends)
+	if err != nil {
+		klog.Error(err)
+		return
+	}
+
+	klog.Infof("refreshing cache for %d services", kd.snapshot.Len())
+	kd.snapshot.Sync()
+
+}
+
+func (kd *AppmeshDiscovery) handleErr(err error, key interface{}) {
+	if err == nil {
+		kd.queue.Forget(key)
+		return
+	}
+
+	if kd.queue.NumRequeues(key) < 5 {
+		klog.Infof("error syncing %v: %v", key, err)
+		kd.queue.AddRateLimited(key)
+		return
+	}
+
+	kd.queue.Forget(key)
+	runtime.HandleError(err)
+	klog.Infof("dropping %q out of the queue: %v", key, err)
+}
+
+func (kd *AppmeshDiscovery) processNextItem() bool {
+	key, quit := kd.queue.Get()
+	if quit {
+		return false
+	}
+	defer kd.queue.Done(key)
+
+	err := kd.sync(key.(string))
+	kd.handleErr(err, key)
+	return true
+}
+
+func (kd *AppmeshDiscovery) runWorker() {
+	for kd.processNextItem() {
+	}
+}
+
+// svcToUpstream converts the App Mesh virtual service to an Upstream
+func (kd *AppmeshDiscovery) svcToUpstream(svc VirtualService) envoy.Upstream {
+	port := uint32(80)
+	for _, value := range svc.Spec.VirtualRouter.Listeners {
+		port = uint32(value.PortMapping.Port)
+	}
+
+	up := envoy.Upstream{
+		Name: fmt.Sprintf("%s-%d", svc.Name, port),
+		Domains: []string{
+			svc.Name,
+			fmt.Sprintf("%s:%d", svc.Name, port),
+		},
+		Port:    port,
+		Host:    svc.Name,
+		Prefix:  "/",
+		Retries: 2,
+		Timeout: 15 * time.Second,
+	}
+
+	appendDomain := func(slice []string, i string) []string {
+		for _, ele := range slice {
+			if ele == i {
+				return slice
+			}
+		}
+		return append(slice, i)
+	}
+
+	for key, value := range svc.Annotations {
+		if key == envoy.AnDomain {
+			up.Domains = appendDomain(up.Domains, value)
+		}
+		if key == envoy.AnTimeout {
+			d, err := time.ParseDuration(value)
+			if err == nil {
+				up.Timeout = d
+			}
+		}
+		if key == envoy.AnRetries {
+			r, err := strconv.Atoi(value)
+			if err == nil {
+				up.Retries = uint32(r)
+			}
+		}
+	}
+	return up
+}
+
+// svcIsValid checks if a virtual service service is eligible
+func (kd *AppmeshDiscovery) svcIsValid(svc VirtualService) bool {
+	for key, value := range svc.Annotations {
+		if key == envoy.AnExpose && value == "false" {
+			return false
+		}
+	}
+	return true
+}
+
+func (kd *AppmeshDiscovery) toVirtualService(obj *unstructured.Unstructured) (*VirtualService, error) {
+	b, _ := json.Marshal(&obj)
+	var svc VirtualService
+	err := json.Unmarshal(b, &svc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &svc, nil
+}
+
+func (kd *AppmeshDiscovery) updateVirtualNode(backends []string) error {
+	vnName := fmt.Sprintf("%s.%s", kd.gatewayName, kd.gatewayNamespace)
+	var vnBackends []Backend
+	for _, value := range backends {
+		vnBackends = append(vnBackends, Backend{
+			VirtualService: VirtualServiceBackend{VirtualServiceName: value},
+		})
+	}
+	spec := VirtualNodeSpec{
+		MeshName: kd.gatewayMesh,
+		Listeners: []Listener{
+			{PortMapping: PortMapping{
+				Port:     444,
+				Protocol: "http",
+			}},
+		},
+		ServiceDiscovery: &ServiceDiscovery{Dns: &DnsServiceDiscovery{
+			HostName: fmt.Sprintf("%s.%s", kd.gatewayName, kd.gatewayNamespace),
+		}},
+		Backends: vnBackends,
+	}
+
+	vn := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "VirtualNode",
+			"apiVersion": "appmesh.k8s.aws/v1beta1",
+			"metadata": map[string]interface{}{
+				"name": vnName,
+			},
+			"spec": spec,
+		},
+	}
+
+	client := kd.clientset.Resource(schema.GroupVersionResource{
+		Group:    "appmesh.k8s.aws",
+		Version:  "v1beta1",
+		Resource: "virtualnodes",
+	})
+
+	_, err := client.Namespace(kd.gatewayNamespace).Get(vnName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		_, createErr := client.Namespace(kd.gatewayNamespace).Create(vn, metav1.CreateOptions{})
+		if createErr != nil && !errors.IsNotFound(createErr) {
+			return fmt.Errorf("failed to create gateway virtual node: %v", err)
+		}
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to get gateway virtual node: %v", err)
+	}
+
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		gw, err := client.Namespace(kd.gatewayNamespace).Get(vnName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		vn = &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"kind":       "VirtualNode",
+				"apiVersion": "appmesh.k8s.aws/v1beta1",
+				"metadata": map[string]interface{}{
+					"name":            vnName,
+					"resourceVersion": gw.GetResourceVersion(),
+				},
+				"spec": spec,
+			},
+		}
+		_, err = client.Namespace(kd.gatewayNamespace).Update(vn, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if retryErr != nil {
+		return fmt.Errorf("failed to update gateway virtual node: %v", retryErr)
+	}
+
+	return nil
+}
+
+type VirtualService struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              VirtualServiceSpec `json:"spec,omitempty"`
+}
+type VirtualServiceSpec struct {
+	VirtualRouter *VirtualRouter `json:"virtualRouter,omitempty"`
+}
+type VirtualRouter struct {
+	Name      string                  `json:"name"`
+	Listeners []VirtualRouterListener `json:"listeners,omitempty"`
+}
+type VirtualRouterListener struct {
+	PortMapping PortMapping `json:"portMapping"`
+}
+type PortMapping struct {
+	Port     int64  `json:"port"`
+	Protocol string `json:"protocol"`
+}
+type VirtualNode struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              VirtualNodeSpec `json:"spec,omitempty"`
+}
+type VirtualNodeSpec struct {
+	MeshName         string            `json:"meshName"`
+	Listeners        []Listener        `json:"listeners,omitempty"`
+	ServiceDiscovery *ServiceDiscovery `json:"serviceDiscovery,omitempty"`
+	Backends         []Backend         `json:"backends,omitempty"`
+}
+type Listener struct {
+	PortMapping PortMapping `json:"portMapping"`
+}
+type ServiceDiscovery struct {
+	Dns *DnsServiceDiscovery `json:"dns,omitempty"`
+}
+type DnsServiceDiscovery struct {
+	HostName string `json:"hostName"`
+}
+type Backend struct {
+	VirtualService VirtualServiceBackend `json:"virtualService"`
+}
+type VirtualServiceBackend struct {
+	VirtualServiceName string `json:"virtualServiceName"`
+}


### PR DESCRIPTION
* watch Kubernetes for App Mesh virtual services events
* generate Envoy clusters and virtual hosts for App Mesh virtual services
* generate an App Mesh virtual node for the gateway
* reconcile the gateway virtual node with the discovered App Mesh virtual services
* add App Mesh gateway deployment kustomization