### PR TITLE
Check if RBAC allows read access to App Mesh objects

### DIFF
--- a/pkg/discovery/controller.go
+++ b/pkg/discovery/controller.go
@@ -131,7 +131,6 @@ func (ctrl *Controller) syncAll() {
 		}
 	}
 
-	klog.Infof("updating gateway virtual node with %d backends", len(backends))
 	err := ctrl.vnManager.Reconcile(backends)
 	if err != nil {
 		klog.Error(err)


### PR DESCRIPTION
Check if RBAC allows read access to App Mesh objects at Gateway startup. Exit with panic if access is denied.