### PR TITLE
Allow mapping a list of custom domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ metadata:
     gateway.appmesh.k8s.aws/expose: "true"
     gateway.appmesh.k8s.aws/retries: "5"
     gateway.appmesh.k8s.aws/timeout: "25s"
-    gateway.appmesh.k8s.aws/domain: "frontend.example.com"
+    gateway.appmesh.k8s.aws/domain: "example.com,www.example.com"
 ```
 
 If you want to expose the service inside the Kubernetes cluster you can omit the domain annotation.

--- a/pkg/discovery/virtualservice.go
+++ b/pkg/discovery/virtualservice.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	appmeshv1 "github.com/aws/aws-app-mesh-controller-for-k8s/pkg/apis/appmesh/v1beta1"
@@ -58,7 +59,12 @@ func (vsm *VirtualServiceManager) ConvertToUpstream(vs appmeshv1.VirtualService)
 
 	for key, value := range vs.Annotations {
 		if key == envoy.GatewayDomain {
-			up.Domains = appendDomain(up.Domains, value)
+			for _, domain := range strings.Split(value, ",") {
+				domain = strings.TrimSpace(domain)
+				if domain != "" {
+					up.Domains = appendDomain(up.Domains, domain)
+				}
+			}
 		}
 		if key == envoy.GatewayTimeout {
 			d, err := time.ParseDuration(value)

--- a/pkg/envoy/annotations.go
+++ b/pkg/envoy/annotations.go
@@ -7,7 +7,7 @@ const (
 	GatewayPrefix = "gateway.appmesh.k8s.aws/"
 	// GatewayExpose expose boolean annotation
 	GatewayExpose = GatewayPrefix + "expose"
-	// GatewayDomain public or internal domain annotation
+	// GatewayDomain annotation with a comma separated list of public or internal domains
 	GatewayDomain = GatewayPrefix + "domain"
 	// GatewayTimeout max response duration annotation
 	GatewayTimeout = GatewayPrefix + "timeout"


### PR DESCRIPTION
This PR adds support for specifying a list of custom domains e.g.:
```yaml
apiVersion: appmesh.k8s.aws/v1beta1
kind: VirtualService
metadata:
  name: frontend.test
  annotations:
    gateway.appmesh.k8s.aws/expose: "true"
    gateway.appmesh.k8s.aws/domain: "frontend.example.com,*.frontend.example.com"
``` 

Fix: #8 